### PR TITLE
Save ~50MB on image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,17 @@ RUN \
         ghostscript \
         imagemagick \
         survex && \
+    apt-get clean && \
+    rm -rf \
+        /var/lib/apt/lists/* \
+        /usr/share/doc/* \
+        /usr/share/info/* \
+        /var/cache/debconf/* && \
     sed -i '/pattern="PDF"/d' /etc/ImageMagick-6/policy.xml
 
 FROM root AS compiling
 RUN \
+    apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         python3 \
@@ -28,7 +35,13 @@ RUN \
         pkg-config \
         tcl \
         libproj-dev \
-        libfmt-dev
+        libfmt-dev && \
+        apt-get clean && \
+        rm -rf \
+            /var/lib/apt/lists/* \
+            /usr/share/doc/* \
+            /usr/share/info/* \
+            /var/cache/debconf/*
 
 COPY ./therion /usr/src/therion/
 WORKDIR /usr/src/therion/
@@ -40,7 +53,6 @@ RUN sed -i 's/^LOCHEXE/##LOCHEXE/' /usr/src/therion/Makefile && \
 FROM root
 COPY --from=compiling /usr/src/therion/therion /usr/local/bin
 RUN \
-    apt-get clean && \
     useradd therion
 ENTRYPOINT ["/usr/local/bin/therion"]
 USER therion


### PR DESCRIPTION
I played around with optimizing sizes - managed to trim 50MB and come down to 450 or so, but that's it. 
I used [dive](https://github.com/wagoodman/dive) to inspect the images and don't think there's anything significant to cut. 
