### PR TITLE
Remove Dockerfile USER to enable GitHub actions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,5 @@ RUN sed -i 's/^LOCHEXE/##LOCHEXE/' /usr/src/therion/Makefile && \
 FROM root
 COPY --from=compiling /usr/src/therion/therion /usr/local/bin
 RUN \
-    apt-get clean && \
-    useradd therion
+    apt-get clean
 ENTRYPOINT ["/usr/local/bin/therion"]
-USER therion


### PR DESCRIPTION
Just noticed that GitHub actions got broken from 6.2.1 onwards. 
Per https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions#user, GitHub actions are executed as root and will be broken if other user is being used. 
While separate user works great locally (but doesn't really add much value), it breaks Github actions, so I propose we revert it back. 
